### PR TITLE
Add alt text requirement to initial-editor-checklist.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/initial-editor-checklist.md
+++ b/.github/ISSUE_TEMPLATE/initial-editor-checklist.md
@@ -17,6 +17,7 @@ assignees: ''
    - [ ] Authorship
    - [ ] License
    - [ ] Conflicts of Interest
+- [ ] All figures have alt texts that describe the content non-visually
 - [ ] Add a notice infobox at the top that the paper is under review w/ link to github issues above the abstract. In Quarto this looks like:
    ```
    ::: {.callout-important appearance="simple"}


### PR DESCRIPTION
Just a basic AX requirement. The rest will come in the AX review but making sure alt texts are there from the beginning reduces one round of feedback. 